### PR TITLE
Move all existing bot resources into README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,52 +1,104 @@
 # Programming Discussions Recommendations
+
 A curated list of learning resources recommended by the Programming Discussions server on Discord.
 
 - [Languages](#languages)
+  - [C#](#c-pronounced-c-sharp)
   - [C++](#c)
   - [Java](#java)
   - [Javascript](#javascript)
   - [PHP](#php)
   - [Python](#python)
+  - [Go](#go)
+  - [Ruby](#ruby)
 - [Language Agnostic](#language-agnostic)
+  - [DSA](#dsa)
+  - [Interviews](#interviews)
+  - [ML](#ml)
 
 ## Languages
+
 ### C# (pronounced c-sharp)
-* [Rob Miles' C# Programming Yellow Book](http://www.robmiles.com/c-yellow-book/) is the go-to guide for learning or refreshing C# skills. 
+
+* [Rob Miles' C# Programming Yellow Book](http://www.robmiles.com/c-yellow-book/) is the go-to guide for learning or refreshing C# skills.
+* [Free Course: Fundamentals for Absolute Beginners](https://mva.microsoft.com/en-us/training-courses/c-fundamentals-for-absolute-beginners-16169)
+* [Video Series: Getting Started with Visual Studio & C# .NET with Nerdgasm](https://www.youtube.com/watch?v=Yj0G5UdBJZw&list=PLEbaEyM-xt9mVQEAXGlRRmbO2Qp_oqF-n)
+* [Book: C# in Depth, Third Edition by Jon Skeet (http://meta.stackexchange.com/q/9134)](https://www.manning.com/books/c-sharp-in-depth-third-edition)
+* [Paid Course Library: Fundamentals, ASP.NET MVC, LINQ, Entity Framework and more](https://teamtreehouse.com/library/topic:csharp)
 
 ### C++
+
 * [Language Reference](http://en.cppreference.com/w/) &mdash; A reference for the C/C++ programming languages.
 * [The Definitive C++ Book Guide and List](http://stackoverflow.com/a/388282) &mdash; A list of recommended books for learning C++, ordered by skill level.
 * [C++ FAQ](https://reddit.com/r/learnprogramming/wiki/faq_cpp) &mdash; The FAQ about C++ on /r/learnprogramming.
 
 ### Java
+
 * [Java Platform Documentation](https://docs.oracle.com/javase/8/docs/api/) &mdash; Official Java SE 8 Documentation.
 * [Oracle Tutorial](https://docs.oracle.com/javase/tutorial/) &mdash; Official Java Tutorial by Oracle.
+
 #### Materials
+
 * [Software Construction](https://ocw.mit.edu/ans7870/6/6.005/s16/) &mdash; MIT 6.005: Software Construction (Warning: Needs some programming experience).
 * [Effective Java](https://www.amazon.com/Effective-Java-2nd-Joshua-Bloch/dp/0321356683) &mdash; For those looking for a deeper understanding of Java, to create clearer, more correct, more robust, and more reusable code.
+
 #### Learning
+
 * [Object Oriented Programming](http://mooc.fi/courses/2013/programming-part-1/) &mdash; Object-Oriented programming with Java, part I & II (University of Helsinki).
 
 ### Javascript
+
 * [Eloquent JavaScript](http://eloquentjavascript.net/) &mdash; Free to Read Online: A Modern Introduction to Programming
 * [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/JavaScript) &mdash; A community wiki with a JavaScript reference section, including compatability charts.
 * [JS The Right Way](http://jstherightway.org/) &mdash; An overview of JS with a list of additional resources.
 * [javascript.info](javascript.info) &mdash; A tutorial on the new features in Javascript.
 * [JS in 2017](https://medium.freecodecamp.org/what-to-learn-in-2017-if-youre-a-frontend-developer-b6cfef46effd) &mdash; "there's a collection of stuff".
+
 #### Videos
+
 * [What the heck is the event loop anyway?](https://youtu.be/8aGhZQkoFbQ) &mdash; Talk: Overview on the Javascript event loop. (26:52)
 
-### php
-#### Materials
-* [*PSR*](http://www.php-fig.org/psr/) &mdash; a collection of community-made standards and best practices for PHP
+#### React
+
+* [Hello World in React](https://facebook.github.io/react/docs/hello-world.html)
+* [Free Course: Get Quickly in Pace with React.js Development](https://www.youtube.com/watch?v=MhkGQAoc7bc&list=PLoYCgNOIyGABj2GQSlDRjgvXtqfDxKm5b)
+* [Free Course: Essential Concepts](https://www.codecademy.com/learn/react-101)
+* [Free Course: Continuation: Lifecycle Methods, Stateless Components and more](https://www.codecademy.com/learn/react-102)
+* [Awesome react](https://github.com/enaqx/awesome-react)
+* [Redux doc's](http://redux.js.org/)
+* [Dan Abramov's free course for redux](https://egghead.io/courses/getting-started-with-redux)
+* [React-redux-links](https://github.com/markerikson/react-redux-links)
+
+### CSS
+
 #### Learning
+
+* [Tutorials/Documentation (In-depth)](https://developer.mozilla.org/en-US/docs/Web/CSS)
+* [A Free Visual Guide to CSS:](http://cssreference.io/)
+* [Free Course: Learn the basics of HTML and CSS](https://codecademy.com/learn/web)
+* [Tutorial: Simple introduction to CSS](http://learnlayout.com/)
+
+#### Materials
+
+* [Tutorials/Documentation (Good for Quick Reference)](https://w3schools.com/css/default.asp)
+
+### PHP
+
+#### Materials
+
+* [*PSR*](http://www.php-fig.org/psr/) &mdash; a collection of community-made standards and best practices for PHP
+
+#### Learning
+
 * [*A simple tutorial*](https://secure.php.net/manual/en/tutorial.php) &mdash; A good introduction.
 * [*Official PHP Documentation*](http://php.net/docs.php) &mdash; Select a language on the page.
 * [*Learn PHP the right way*](http://www.phptherightway.com/) &mdash; Free online free book/reference manual.
 * [*PHP 7*](http://www.tutorialspoint.com/php7/) &mdash; Interactive tutorial http://www.tutorialspoint.com/
 
 ### Python
+
 #### Learning
+
 * [*Automate the Boring Stuff*](http://automatetheboringstuff.com) by Al
   Sweigart &mdash; An introduction to the language focused on showing how Python
   can help you with tasks around the office today.
@@ -56,17 +108,73 @@ A curated list of learning resources recommended by the Programming Discussions 
 * [*Corey Schafer on Youtube*](https://www.youtube.com/user/schafer5) &mdash; Useful Youtube channel with plenty of good quality tutorials
 
 #### Culture
+
 * [*Talk Python to Me*](https://talkpython.fm) by Michael Kennedy &mdash;
   A weekly discussion about a Python project you should know about, usually with
   their developers.
 
+### Go
+
+#### Learning
+
+* [Documentation](https://golang.org/doc/)
+* [Official Tour](https://tour.golang.org/welcome/1)
+* [Introductory Video](https://www.youtube.com/watch?v=CF9S4QZuV30)
+* [Effective Go <- READ THIS](https://golang.org/doc/effective_go.html)
+
+#### Materials
+
+* [Godoc](https://godoc.org/)
+
+### Ruby
+
+#### Learning
+
+* [Official Ruby Core 2.4.1 Documentation](http://ruby-doc.org/core-2.4.1/)
+* [Quickstart Guide: Ruby In Twenty Minutes](https://www.ruby-lang.org/en/documentation/quickstart/)
+* [Cheatsheet/Reference:](http://www.cheat-sheets.org/saved-copy/RubyCheat.pdf)
+* [Learn to Program with Ruby](https://pine.fm/LearnToProgram/)
+* [Free (Language Transition): Ruby From Other Languages](https://www.ruby-lang.org/en/documentation/ruby-from-other-languages/)
+* [Free (Exercise Focused): Learn Ruby the Hard Way](https://learnrubythehardway.org/book/)
+* [Free (Exercise Focused): Codecademy Ruby](https://www.codecademy.com/learn/ruby)
+* [Free (Ruby on Rails 5) : Ruby on Rails Tutorial](https://www.railstutorial.org/book/)
+* [Free (Ruby on Rails): Learn Ruby on Rails from Scratch](https://www.udemy.com/learn-ruby-on-rails-from-scratch)
+* [Paid (Course Library): TeamTreehouse: Learn Ruby](https://teamtreehouse.com/tracks/learn-ruby)
+
 ## Language Agnostic
 
+### DSA
+
+* [Free Course - Sedgewick's Coursera Part 1](https://www.coursera.org/learn/algorithms-part1)
+* [Free Course - Sedgewick's Coursera Part 2](https://www.coursera.org/learn/algorithms-part2)
+* [Paid Book - Sedgewick's Algorithms in Java](http://algs4.cs.princeton.edu/home/)
+* [Paid Book - CLRS/Introduction to Algorithms](https://mitpress.mit.edu/books/introduction-algorithms)
+
+### Interviews
+
+* [Paid Book - Cracking the Coding Interview, 6th Edition](http://www.crackingthecodinginterview.com/)
+* [Paid Book - Programming Interviews Exposed](https://www.amazon.com/Programming-Interviews-Exposed-Secrets-Landing/dp/1118261364)
+* [Paid Book - Elements of Programming Interviews !WARNING COMES IN SEVERAL LANGUAGES!](https://bit.ly/epipython)
+
+### Machine Learning
+
+* [Free Course - Andrew Ng's Course](https://www.coursera.org/learn/machine-learning)
+* [Free Book - Introduction to Statistical Learning](http://www-bcf.usc.edu/~gareth/ISL/)
+* [Free Book - Deep Learning Book - !WARNING MATH HEAVY!](http://www.deeplearningbook.org/)
+* [Free Book - Neural Networks and Deep Learning - !WARNING MATH HEAVY!](http://neuralnetworksanddeeplearning.com/chap1.html)
+* [YouTube - Sentdex](https://www.youtube.com/sentdex)
+* [YouTube - Siraj Raval](https://www.youtube.com/channel/UCWN3xxRkmTPmbKwht9FuE5A)
+
 ### Podcasts
+
 * [Programming Throwdown](http://www.programmingthrowdown.com/) &mdash; Every show covers a new programming language and assorted tech topics.
 * [Coding Blocks](https://www.codingblocks.net/) &mdash; Pragmatic talk about software design best practices: design patterns, software architecture, performance, object oriented programming, and database design.
+* [*Coder Radio* by Jupiter Broadcasting](http://www.jupiterbroadcasting.com/show/coderradio/)
+* [*Talk Python to Me* by Michael Kennedy](https://talkpython.fm)
+* [*Simple Programmer* by John Sonmez](https://www.youtube.com/playlist?list=PLjwWT1Xy3c4U4xrSdGiN9fh04NjHoNwTq)
 
 # License
+
 [![CC0](http://mirrors.creativecommons.org/presskit/buttons/88x31/svg/cc-zero.svg)](https://creativecommons.org/publicdomain/zero/1.0/)
 
 To the extent possible under law, the Programming Discussions community has


### PR DESCRIPTION
All bot resources from https://github.com/progdisc/AwesomeBot/tree/master/commands/help/topics parsed with a regex into markdown. 

Minor issues
* Keep "Sedgewick's Algorithms in Java" under DSA or move it into Java?
* What exactly are "materials", some added resources might be under material against spec.

Non Bot Related Changes
* Added the link to the C# header
* Spaced out headers 