### PR TITLE
[RFC] Making headers clearer and adding search words

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,15 @@ A curated list of learning resources recommended by the Programming Discussions 
   - [Ruby](#ruby)
   - [Rust](#rust)
 - [Language Agnostic](#language-agnostic)
-  - [DSA](#dsa)
+  - [Data Structures & Algorithms](#data-structures-algorithms)
   - [Interviews](#interviews)
-  - [ML](#ml)
+  - [Machine Learning](#machine-learning)
 
 ## Languages
 
-### C# (pronounced c-sharp)
+### C#
+
+Search words: c-sharp, csharp
 
 * [Rob Miles' C# Programming Yellow Book](http://www.robmiles.com/c-yellow-book/) is the go-to guide for learning or refreshing C# skills.
 * [Free Course: Fundamentals for Absolute Beginners](https://mva.microsoft.com/en-us/training-courses/c-fundamentals-for-absolute-beginners-16169)
@@ -28,6 +30,8 @@ A curated list of learning resources recommended by the Programming Discussions 
 * [Paid Course Library: Fundamentals, ASP.NET MVC, LINQ, Entity Framework and more](https://teamtreehouse.com/library/topic:csharp)
 
 ### C++
+
+Search words: cpp
 
 * [Language Reference](http://en.cppreference.com/w/) &mdash; A reference for the C/C++ programming languages.
 * [The Definitive C++ Book Guide and List](http://stackoverflow.com/a/388282) &mdash; A list of recommended books for learning C++, ordered by skill level.
@@ -48,6 +52,8 @@ A curated list of learning resources recommended by the Programming Discussions 
 * [Object Oriented Programming](http://mooc.fi/courses/2013/programming-part-1/) &mdash; Object-Oriented programming with Java, part I & II (University of Helsinki).
 
 ### Javascript
+
+Search words: JS, ES5, ES6, ES2017
 
 * [Eloquent JavaScript](http://eloquentjavascript.net/) &mdash; Free to Read Online: A Modern Introduction to Programming
 * [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/JavaScript) &mdash; A community wiki with a JavaScript reference section, including compatability charts.
@@ -71,6 +77,8 @@ A curated list of learning resources recommended by the Programming Discussions 
 * [React-redux-links](https://github.com/markerikson/react-redux-links)
 
 ### CSS
+
+Search words: Cascading Style Sheets
 
 #### Learning
 
@@ -129,6 +137,8 @@ A curated list of learning resources recommended by the Programming Discussions 
 
 ### Ruby
 
+Search words: Ruby on Rails
+
 #### Learning
 
 * [Official Ruby Core 2.4.1 Documentation](http://ruby-doc.org/core-2.4.1/)
@@ -150,7 +160,7 @@ A curated list of learning resources recommended by the Programming Discussions 
 * [Rust By Example](http://rustbyexample.com/) &mdash; A nice tutorial for people who already know how to program.
 * [The Little Book of Rust Macros](https://danielkeep.github.io/tlborm/book/index.html) &mdash; Everything you need to know about macros.
 * [Rust Documentation](https://doc.rust-lang.org/) &mdash; List of useful Rust documentations, such as: The Rust Language Reference & The standard library API.
-* [The Rustonomicon](https://doc.rust-lang.org/nomicon/README.html#the-rustonomicon) &mdash; The Dark Arts of Advanced and Unsafe Rust Programming. 
+* [The Rustonomicon](https://doc.rust-lang.org/nomicon/README.html#the-rustonomicon) &mdash; The Dark Arts of Advanced and Unsafe Rust Programming.
 * [Rustdoc Guide](https://doc.rust-lang.org/rustdoc/) &mdash; A short guide on rustdoc and how to use it.
 * [Awesome Rust](https://github.com/kud1ing/awesome-rust) &mdash; A huge list of the best crates and tools you could possibly think of!
 * [Rust Books](https://github.com/sger/RustBooks) &mdash; A collection of books related to Rust.
@@ -158,7 +168,9 @@ A curated list of learning resources recommended by the Programming Discussions 
 
 ## Language Agnostic
 
-### DSA
+### Data Structures & Algorithms
+
+Search words: DSA
 
 * [Free Course - Sedgewick's Coursera Part 1](https://www.coursera.org/learn/algorithms-part1)
 * [Free Course - Sedgewick's Coursera Part 2](https://www.coursera.org/learn/algorithms-part2)
@@ -172,6 +184,8 @@ A curated list of learning resources recommended by the Programming Discussions 
 * [Paid Book - Elements of Programming Interviews !WARNING COMES IN SEVERAL LANGUAGES!](https://bit.ly/epipython)
 
 ### Machine Learning
+
+Search words: ML
 
 * [Free Course - Andrew Ng's Course](https://www.coursera.org/learn/machine-learning)
 * [Free Book - Introduction to Statistical Learning](http://www-bcf.usc.edu/~gareth/ISL/)


### PR DESCRIPTION
What do you guys think? I thought the abbreviated headers should be clearer, so anyone can understand them at first glance. To facilitate search inside the page, I added some keywords where it made sense.

Still need to:
- [x] review and fix TOC links