### PR TITLE
Update Helsinki MOOC name and link

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Search words: cpp
 
 #### Learning
 
-* 🆓🎓 [Object Oriented Programming](http://mooc.fi/courses/2013/programming-part-1/) &mdash; MOOC taught with Java, part I & II (University of Helsinki).
+* 🆓🎓 [Java Programming](https://java-programming.mooc.fi/) &mdash; MOOC taught with Java, part I & II (University of Helsinki).
 
 ### Javascript
 


### PR DESCRIPTION
The previous link was to an outdated version of the Helsinki MOOC.  This
is the new URL and new name of the course.