### PR TITLE
Update list to include UI/UX resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
   * [SQL](#sql)
 * [Language Agnostic](#language-agnostic)
   * [Data Structures & Algorithms](#data-structures--algorithms)
+  * [Design](#design)
   * [Git](#git)
   * [Interviews](#interviews)
   * [Machine Learning](#machine-learning)
@@ -249,7 +250,7 @@ Search words: DSA
 
 Search words: UI, UX, design
 
-* 🆓📘 [CalArts UI/UX Design Specialization](https://www.coursera.org/specializations/ui-ux-design) By Michael Worthington and Roman Jaster, Coursera
+* 🆓🎓 [CalArts UI/UX Design Specialization](https://www.coursera.org/specializations/ui-ux-design) By Michael Worthington and Roman Jaster, Coursera
 * 🆓🎓 [Springboard UX Design Curriculum](https://www.springboard.com/resources/learning-paths/user-experience-design/)
 
 ### Git

--- a/README.md
+++ b/README.md
@@ -250,8 +250,8 @@ Search words: DSA
 
 Search words: UI, UX, design
 
-* 🆓🎓 [CalArts UI/UX Design Specialization](https://www.coursera.org/specializations/ui-ux-design) By Michael Worthington and Roman Jaster, Coursera
-* 🆓🎓 [Springboard UX Design Curriculum](https://www.springboard.com/resources/learning-paths/user-experience-design/)
+* 🆓🎓 [CalArts UI/UX Design Specialization](https://www.coursera.org/specializations/ui-ux-design) &mdash; 4-course series on UI/UX design and wireframing with a web-app approach.
+* 🆓🎓 [Springboard UX Design Curriculum](https://www.springboard.com/resources/learning-paths/user-experience-design/) &mdash; Aggregator of links to UI/UX tutorials and resources.
 
 ### Git
 * 🆓🎮 [Learn Git Branching](https://learngitbranching.js.org/) &mdash; Interactive introduction to Git branching and workflow.

--- a/README.md
+++ b/README.md
@@ -245,6 +245,13 @@ Search words: DSA
 * 💲📘 [Sedgewick's Algorithms in Java](http://algs4.cs.princeton.edu/home/)
 * 💲📘 [CLRS/Introduction to Algorithms](https://mitpress.mit.edu/books/introduction-algorithms)
 
+### Design
+
+Search words: UI, UX, design
+
+* 🆓📘 [CalArts UI/UX Design Specialization](https://www.coursera.org/specializations/ui-ux-design) By Michael Worthington and Roman Jaster, Coursera
+* 🆓🎓 [Springboard UX Design Curriculum](https://www.springboard.com/resources/learning-paths/user-experience-design/)
+
 ### Git
 * 🆓🎮 [Learn Git Branching](https://learngitbranching.js.org/) &mdash; Interactive introduction to Git branching and workflow.
 * 🆓📘 [Pro Git](https://git-scm.com/book/en/v2) &mdash; A start-to-finish book on how to use and understand Git.


### PR DESCRIPTION
Adds two resources under a new "Design" section:

-- UI/UX courses by CalArts, Coursera specialization
-- UX curriculum by Springboard

This was mentioned in the Discord and some resources were shared. Figured it'd make sense to merge them into the progdisc repo for future reference.