### PR TITLE
Fix haskell anchor

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   * [Javascript](#javascript)
   * [PHP](#php)
   * [Python](#python)
-  * [Haskell](#Haskell)
+  * [Haskell](#haskell)
   * [Go](#go)
   * [Ruby](#ruby)
   * [Rust](#rust)


### PR DESCRIPTION
This commit allows the `Haskell` entry in the Table of Contents to correctly link to the `Haskell` section.