### PR TITLE
Add Agent QA documentation to Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ A good test (by [samwho](http://samwho.co.uk)):
 3. Will not break when the implementation of what's being tested is changed.
 4. Does not depend on anything from the outside world, and leaves nothing behind when it's done.
 
+* 🆓📘 [Agent QA documentation](https://vostride.com/docs/agent-qa/quickstart) &mdash; Guide to writing natural-language web and mobile tests, running them from the command line, and reviewing results.
 * 💲📘 [*Beautiful Testing*](http://shop.oreilly.com/product/9780596159825.do) &mdash; Essays that break down testing as a philosophy, as a process, and as aided by good tools.
 
 # License


### PR DESCRIPTION
Add the freely readable Agent QA quickstart to **Testing**, using the free/documentation emoji markers and the existing `&mdash;` format. It covers authoring natural-language web/mobile tests, running them, and reviewing results.

The new documentation link passes HTTP validation. `npm test` produces exactly the same 114 spelling findings on upstream and this change, with none on the added line. The free marker describes access to the documentation; running Agent QA can incur model/browser/device provider costs.

Affiliation: I maintain Agent QA. This contribution was prepared with AI assistance.
